### PR TITLE
Remove maven* repositories and maven-publish

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,6 @@ buildscript {
 
 allprojects {
     repositories {
-        mavenLocal()
         google()
         jcenter()
         maven { url 'https://dl.bintray.com/kotlin/kotlin-dev' }

--- a/greeting/build.gradle
+++ b/greeting/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.multiplatform'
-    id 'maven-publish'
 }
 
 group = 'org.greeting'

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,8 +14,6 @@ pluginManagement {
     }
 
     repositories {
-        mavenLocal()
-        mavenCentral()
         google()
         jcenter()
         maven { url 'https://dl.bintray.com/kotlin/kotlin-dev' }


### PR DESCRIPTION
I've just removed the mavenCentral() repo (since jcenter() mirrors it anyways).
I also removed the maven-publish plugin together with the `mavenLocal()` repo because I don't think we need it, right?
Or is this included because of some testing?
Maybe then we need a better documentation? 🤔 