### PR TITLE
Fix command to run kotlin tests on iOS simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To run kotlin tests (including the [common ones](greeting/src/commonTest/kotlin/
 on an iOS simulator execute:
 
 ```
-  > ./gradlew :greeting:iosSimTest
+  > ./gradlew :greeting:iosTest
 ```
 
 By default the `iPhone 8` simulator is used. One can change this setting using the `iosDevice` project property:


### PR DESCRIPTION
I think the task is supposed to be iosTest instead of iosSimTest